### PR TITLE
feat(stepfunctions): add parallel url checker workflow

### DIFF
--- a/statemachine/state-machine.json
+++ b/statemachine/state-machine.json
@@ -1,0 +1,110 @@
+{
+  "Comment": "Parallel URL Health Checker - Checks multiple URLs concurrently",
+  "StartAt": "CheckURLs",
+  "States": {
+    "CheckURLs": {
+      "Type": "Map",
+      "ItemsPath": "$.urls",
+      "MaxConcurrency": 5,
+      "Iterator": {
+        "StartAt": "CheckSingleURL",
+        "States": {
+          "CheckSingleURL": {
+            "Type": "Task",
+            "Resource": "${CheckUrlLambdaArn}",
+            "Retry": [
+              {
+                "ErrorEquals": [
+                  "Lambda.ServiceException",
+                  "Lambda.AWSLambdaException",
+                  "Lambda.SdkClientException"
+                ],
+                "IntervalSeconds": 2,
+                "MaxAttempts": 3,
+                "BackoffRate": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "HandleError",
+                "ResultPath": "$.error_info"
+              }
+            ],
+            "End": true
+          },
+          "HandleError": {
+            "Type": "Pass",
+            "Parameters": {
+              "url.$": "$.url",
+              "status": "unhealthy",
+              "error": "Lambda execution failed",
+              "error_details.$": "$.error_info"
+            },
+            "End": true
+          }
+        }
+      },
+      "ResultPath": "$.results",
+      "Next": "AggregateResults"
+    },
+    "AggregateResults": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${CheckHealthStatusLambdaArn}",
+        "Payload": {
+          "results.$": "$.results"
+        }
+      },
+      "ResultPath": "$.health_check",
+      "Next": "AddSummary"
+    },
+    "AddSummary": {
+      "Type": "Pass",
+      "Parameters": {
+        "total_urls.$": "States.ArrayLength($.results)",
+        "results.$": "$.results",
+        "has_unhealthy.$": "$.health_check.Payload.has_unhealthy",
+        "summary": {
+          "execution_time.$": "$$.State.EnteredTime",
+          "execution_id.$": "$$.Execution.Name"
+        }
+      },
+      "Next": "CheckIfAnyUnhealthy"
+    },
+    "CheckIfAnyUnhealthy": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.has_unhealthy",
+          "BooleanEquals": true,
+          "Next": "SendAlert"
+        }
+      ],
+      "Default": "AllHealthy"
+    },
+    "SendAlert": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "${SNSTopicArn}",
+        "Subject": "URL Health Check Alert - Some URLs are Down",
+        "Message.$": "States.Format('Health check completed.\n\nTotal URLs checked: {}\n\nUnhealthy URLs detected! Check the execution details.\n\nExecution ID: {}\n\nResults:\n{}', $.total_urls, $.summary.execution_id, States.JsonToString($.results))"
+      },
+      "ResultPath": "$.notification",
+      "Next": "Complete"
+    },
+    "AllHealthy": {
+      "Type": "Pass",
+      "Result": {
+        "message": "All URLs are healthy!"
+      },
+      "ResultPath": "$.health_status",
+      "Next": "Complete"
+    },
+    "Complete": {
+      "Type": "Succeed"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds Step Functions state machine to orchestrate parallel URL health checks with error handling and alerting.

Closes #3

## Changes
- Create state-machine.json definition
- Add Map state for parallel processing (MaxConcurrency: 5)
- Add retry logic with exponential backoff (3 attempts, 2x backoff)
- Add error handling states with Catch blocks
- Add health check aggregation using Lambda invoke
- Add Choice state for conditional logic
- Add SNS alert integration for unhealthy URLs
- Add success state for all healthy scenarios

## Testing
- Tested with all healthy URLs
- Tested with failed URLs triggering alerts
- Tested retry logic with transient failures
- Verified parallel execution in CloudWatch

## Type of Change
- [x] New feature

## AWS Resources Modified
- [x] Step Functions State Machine